### PR TITLE
Fixed #5: meanBy returns NAN when listProperty is a relationship

### DIFF
--- a/addon/index.js
+++ b/addon/index.js
@@ -95,7 +95,7 @@ export var meanBy = function(listProperty, valueProperty) {
     const list = get(this, listProperty);
     return list.reduce((sum, item) => {
       return sum + (get(item, valueProperty) || 0);
-    }, 0) / list.length;
+    }, 0) / get(list, 'length');
   }).readOnly();
 };
 

--- a/tests/dummy/app/models/child.js
+++ b/tests/dummy/app/models/child.js
@@ -1,0 +1,5 @@
+import DS from 'ember-data';
+
+export default DS.Model.extend({
+  age: DS.attr('number')
+});

--- a/tests/dummy/app/models/parent.js
+++ b/tests/dummy/app/models/parent.js
@@ -1,0 +1,7 @@
+import DS from 'ember-data';
+import { meanBy } from 'ember-array-computed-macros';
+
+export default DS.Model.extend({
+  children:     DS.hasMany('children', {async: true}),
+  meanChildAge: meanBy('children', 'age')
+});

--- a/tests/unit/mean-test.js
+++ b/tests/unit/mean-test.js
@@ -1,9 +1,18 @@
 import Ember from 'ember';
-import { module, test } from 'qunit';
+
+const {
+  run
+} = Ember;
+
+import { moduleForModel, test } from 'ember-qunit';
 
 import { meanBy } from 'ember-array-computed-macros';
 
-module('Unit | Computed | meanBy');
+
+moduleForModel('parent', 'Unit | Computed | meanBy', {
+  // Specify the other units that are required for this test.
+  needs: ['model:child']
+});
 
 test('Sums a list of values', (assert) => {
   const subject = Ember.Object.extend({
@@ -11,4 +20,19 @@ test('Sums a list of values', (assert) => {
   }).create({ list: [{ score: 1 }, { score: 10 }, { score: 4 }] });
 
   assert.equal(subject.get('meanValue'), 5);
+});
+
+
+test('Sums a list of values from async relationship', function (assert) {
+  run(() => {
+    const store  = this.store();
+    const parent = this.subject({
+      children: [
+        store.createRecord('child', {age: 2}),
+        store.createRecord('child', {age: 4})
+      ]
+    });
+
+    assert.equal(parent.get('meanChildAge'), 3);
+  });
 });


### PR DESCRIPTION
Includes #7 (tests didn't work without it).

A failing test for #5 is in a separate commit: you can check it out to ensure the problem exists and is indeed fixed by the subsequent commit.