### PR TITLE
Fix bug with reduce and reduceBy

### DIFF
--- a/addon/index.js
+++ b/addon/index.js
@@ -1,6 +1,6 @@
 import Ember from 'ember';
 
-const { compare, computed, get, isEqual } = Ember;
+const { compare, computed, get, isEqual, isNone } = Ember;
 
 // For your convenience
 export var map      = Ember.computed.map;
@@ -146,10 +146,10 @@ export var groupBy = function(listProperty, valueProperty) {
 
 export var reduce = function(listProperty, reduceFunction, initValue) {
   return computed(`${listProperty}.[]`, function() {
-    if (initValue) {
-      return get(this, listProperty).reduce(reduceFunction, initValue);
-    } else {
+    if (isNone(initValue)) {
       return get(this, listProperty).reduce(reduceFunction);
+    } else {
+      return get(this, listProperty).reduce(reduceFunction, initValue);
     }
   }).readOnly();
 };
@@ -159,10 +159,10 @@ export var reduceBy = function(listProperty, valueProperty, reduceFunction, init
     const values = get(this, listProperty)
       .map(function(item) { return get(item, valueProperty); });
 
-    if (initValue) {
-      return values.reduce(reduceFunction, initValue);
-    } else {
+    if (isNone(initValue)) {
       return values.reduce(reduceFunction);
+    } else {
+      return values.reduce(reduceFunction, initValue);
     }
   }).readOnly();
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-array-computed-macros",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "This addon is supplemental to the already existing computed macros existing in Ember.js",
   "directories": {
     "doc": "doc",

--- a/tests/unit/reduce-test.js
+++ b/tests/unit/reduce-test.js
@@ -29,10 +29,32 @@ test('Reduce by property', (assert) => {
   assert.equal(subject.get('summedFooBars'), 6);
 });
 
-test('Reduce by property witn an initial value', (assert) => {
+test('Reduce by property with an initial value', (assert) => {
   const subject = Ember.Object.extend({
     summedFooBars: reduceBy('foos', 'bar', function(memo, value) { return memo + value; }, 1)
   }).create({ foos: [{ bar: 1 }, { bar: 2 }, { bar: 3 }] });
 
   assert.equal(subject.get('summedFooBars'), 7);
+});
+
+test('reduce with an initial value of zero', (assert) => {
+  const subject = Ember.Object.extend({
+    summedFoos: reduce('foos', function(memo, value) {
+      if (value > 0) { memo += 1; }
+      return memo;
+    }, 0)
+  }).create({ foos: [10, 0, 3, 0, 20] });
+
+  assert.equal(subject.get('summedFoos'), 3);
+});
+
+test('reduce by property with an initial value of zero', (assert) => {
+  const subject = Ember.Object.extend({
+    summedFooBars: reduceBy('foos', 'bar', function(memo, value) {
+      if (value > 0) { memo += 1; }
+      return memo;
+    }, 0)
+  }).create({ foos: [{ bar: 10 }, { bar: 0 }, { bar: 5 }] });
+
+  assert.equal(subject.get('summedFooBars'), 2);
 });


### PR DESCRIPTION
See #13. Basically, when the initial value is set to zero the implementation of reduce and reduceBy interpret it as a nonexistent value so you get different arguments during the iteration of the reduceFunction argument. With this change, only if the initialValue argument is `undefined` or `null` then it will be evaluated as not having passed an initialValue. 

I also made a minor version bump on the package.json file. 